### PR TITLE
Return $promise in route resolve

### DIFF
--- a/webapp/src/app/notes/notes.js
+++ b/webapp/src/app/notes/notes.js
@@ -7,7 +7,7 @@ angular.module('app.notes', [
 		templateUrl: 'app/notes/notes.tpl.html',
 		resolve: {
 			notesList: function(NotesService) {
-				return NotesService.query();
+				return NotesService.query().$promise;
 			}
 		}
 	});


### PR DESCRIPTION
Imagine the following code snippet:

``` javascript
function('NotesCtrl', function(notesList) {
    console.log(notesList);
}
```

Without returning `$promise`, this will always print `[]`. However _with_ `$promise` it will print the actual list of items returned from the server.
